### PR TITLE
Revert to core18

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -19,12 +19,12 @@ grade: stable
 confinement: strict
 compression: lzo
 
-architectures:
-  - build-on: amd64
-  - build-on: arm64
-  - build-on: armhf
-  - build-on: ppc64el
-  - build-on: s390x
+#architectures:
+#  - build-on: amd64
+#  - build-on: arm64
+#  - build-on: armhf
+#  - build-on: ppc64el
+#  - build-on: s390x
 
 apps:
   mc-server-installer:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,7 +14,7 @@ description: |
 
 license: MIT
 
-base: core20
+base: core18
 grade: stable
 confinement: strict
 compression: lzo

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -17,7 +17,7 @@ license: MIT
 base: core20
 grade: stable
 confinement: strict
-#compression: lzo
+compression: lzo
 
 architectures:
   - build-on: amd64


### PR DESCRIPTION
Core20 fails to release after build - unknown reasons. LZO compression enabled. 