### PR TITLE
Root check; EULA agreement verification

### DIFF
--- a/scripts/mc-server-installer
+++ b/scripts/mc-server-installer
@@ -49,7 +49,7 @@ while true; do
             curl -so server.jar $JAR_URL
             ;;
         2)
-            if ! grep -q "eula=true" ~/eula.txt; then
+            if ! grep -q "eula=true" eula.txt; then
                 dialog --title "EULA" --infobox "Setting things up first...\n\n Agreeing to the EULA...\n\nIgnore any errors, as they are normal..." 10 50
                 sleep 1.0
                 tmux new-session -d -s mcserver "$JAVA_HOME/bin/java -Xmx2048M -Xms128M -XX:+UseG1GC -jar server.jar nogui"

--- a/scripts/mc-server-installer
+++ b/scripts/mc-server-installer
@@ -2,7 +2,7 @@
 
 # Minecraft Server Installer with TUI using dialog
 
-[ $(id -u) -eq 0 ] && dialog --title "Root detected" --msgbox "Running a game server as root is a bad idea. Exiting." 6 50 && exit 1
+[ $(id -u) = 0 ] && dialog --title "Root detected" --msgbox "Running a game server as root is a bad idea. Exiting." 6 50 && exit 1
 
 JAVA_VER=$(ls $SNAP/usr/lib/jvm/ | grep java | head -n 1)
 LATEST=$(curl -fsSL 'https://launchermeta.mojang.com/mc/game/version_manifest.json' | jq -r '.latest.release')

--- a/scripts/mc-server-installer
+++ b/scripts/mc-server-installer
@@ -2,6 +2,8 @@
 
 # Minecraft Server Installer with TUI using dialog
 
+[ $(id -u) -eq 0 ] && dialog --title "Root detected" --msgbox "Running a game server as root is a bad idea. Exiting." 6 50 && exit 1
+
 JAVA_VER=$(ls $SNAP/usr/lib/jvm/ | grep java | head -n 1)
 LATEST=$(curl -fsSL 'https://launchermeta.mojang.com/mc/game/version_manifest.json' | jq -r '.latest.release')
 INSTALLED=$(ls /home/$USER/snap/mc-server-installer/current/versions/ 2>/dev/null | sort -n | tail -1 || echo "None")

--- a/scripts/mc-server-installer
+++ b/scripts/mc-server-installer
@@ -47,19 +47,23 @@ while true; do
             curl -so server.jar $JAR_URL
             ;;
         2)
-            dialog --title "EULA" --infobox "Setting things up first...\n\n Agreeing to the EULA...\n\nIgnore any errors, as they are normal..." 10 50
-            sleep 1.0
-            tmux new-session -d -s mcserver "$JAVA_HOME/bin/java -Xmx2048M -Xms128M -XX:+UseG1GC -jar server.jar nogui"
-            SERVER_PID=$(pgrep -f "java.*server.jar")
-            sleep 2
-            sed -i 's/false/true/g' eula.txt 2>/dev/null || echo "eula=true" > eula.txt
-            tmux send-keys -t mcserver "stop" C-m
-            sleep 2
-            if kill -0 "$SERVER_PID" 2>/dev/null; then
-                kill "$SERVER_PID"
+            if ! grep -q "eula=true" ~/eula.txt; then
+                dialog --title "EULA" --infobox "Setting things up first...\n\n Agreeing to the EULA...\n\nIgnore any errors, as they are normal..." 10 50
+                sleep 1.0
+                tmux new-session -d -s mcserver "$JAVA_HOME/bin/java -Xmx2048M -Xms128M -XX:+UseG1GC -jar server.jar nogui"
+                SERVER_PID=$(pgrep -f "java.*server.jar")
+                sleep 2
+                sed -i 's/false/true/g' eula.txt 2>/dev/null || echo "eula=true" > eula.txt
+                tmux send-keys -t mcserver "stop" C-m
+                sleep 2
+                if kill -0 "$SERVER_PID" 2>/dev/null; then
+                    kill "$SERVER_PID"
+                fi
+                SERVER_PID=""
+                dialog --msgbox "Done!" 6 30
+            else
+                dialog --msgbox "The EULA has already been accepted!" 6 40
             fi
-            SERVER_PID=""
-            dialog --msgbox "Done!" 6 30
             ;;
         3)
             dialog --title "Editing" --infobox "Opening the server.properties file..." 6 40


### PR DESCRIPTION
I added a verification for whether the EULA has already been agreed with – resulting in an appropriate message –, as well as an early root check which when necessary exits for security reasons.